### PR TITLE
fix ARIN to handle rwhois:// ReferralServer responses

### DIFF
--- a/Templates/Arin.php
+++ b/Templates/Arin.php
@@ -114,7 +114,7 @@ class Arin extends Regex
             $referralServer = $Result->referral_server;
             $Result->reset();
             $mapping = $Config->get($referralServer);
-            $template = str_replace('whois://', '', $mapping['template']);
+            $template = str_replace('whois://', '', str_replace('rwhois://', '', $mapping['template']));
             $Config->setCurrent($Config->get($template));
             $WhoisParser->call();
         }


### PR DESCRIPTION
This fixes "odd" ARIN responses where ReferralServer is `rwhois://` instead of `whois://`.