### PR TITLE
Use cached ARIN WHOIS data in event of referral server connection failure exception

### DIFF
--- a/Adapter/Socket.php
+++ b/Adapter/Socket.php
@@ -134,6 +134,7 @@ class Socket extends AbstractAdapter
 
         if (isset($parsed_socket['port'])) {
             $config['port'] = $parsed_socket['port'];
+            $config['server'] = $parsed_socket['host'];
         }
 
         if ($this->proxyList !== false) {

--- a/Parser.php
+++ b/Parser.php
@@ -209,22 +209,28 @@ class Parser
             $this->Config->setCurrent($config);
             $this->call();
         } catch (AbstractException $e) {
-            if ($this->throwExceptions) {
-                throw $e;
-            }
-            
-            $this->Result->addItem('exception', $e->getMessage());
-            $this->Result->addItem('rawdata', $this->rawdata);
-            
-            if (isset($this->Query)) {
-                
-                if (isset($this->Query->ip)) {
-                    $this->Result->addItem('name', $this->Query->ip);
-                } else {
-                    $this->Result->addItem('name', $this->Query->fqdn);
-                }
+            if (strpos($e->getMessage(), 'Unable to connect') !== false) {
+                // If unable to connect, use the prereferralconfig
+                //  Some referall servers fail, timeout, etc.
+                return $this->Config->prereferralResult;
             } else {
-                $this->Result->addItem('name', $query);
+                if ($this->throwExceptions) {
+                    throw $e;
+                }
+
+                $this->Result->addItem('exception', $e->getMessage());
+                $this->Result->addItem('rawdata', $this->rawdata);
+
+                if (isset($this->Query)) {
+
+                    if (isset($this->Query->ip)) {
+                        $this->Result->addItem('name', $this->Query->ip);
+                    } else {
+                        $this->Result->addItem('name', $this->Query->fqdn);
+                    }
+                } else {
+                    $this->Result->addItem('name', $query);
+                }
             }
         }
         

--- a/Templates/Arin.php
+++ b/Templates/Arin.php
@@ -110,7 +110,7 @@ class Arin extends Regex
             }
         }
         
-        if (isset($Result->referral_server) && $Result->referral_server != '' && $Result->referral_server != 'rwhois://rwhois.shawcable.net:4321' && $Result->referral_server != 'rwhois://rwhois.perfectip.net:4321') {
+        if (isset($Result->referral_server) && $Result->referral_server != '' && $Result->referral_server != 'rwhois://rwhois.shawcable.net:4321' && $Result->referral_server != 'rwhois://rwhois.perfectip.net:4321' && $Result->referral_server != 'rwhois://rwhois.xmission.com:4321') {
             $referralServer = $Result->referral_server;
             $Result->reset();
             $mapping = $Config->get($referralServer);

--- a/Templates/Arin.php
+++ b/Templates/Arin.php
@@ -111,11 +111,15 @@ class Arin extends Regex
         }
         
         if (isset($Result->referral_server) && $Result->referral_server != '' && $Result->referral_server != 'rwhois://rwhois.psychz.net:4321' && $Result->referral_server != 'rwhois://rwhois.shawcable.net:4321' && $Result->referral_server != 'rwhois://rwhois.perfectip.net:4321' && $Result->referral_server != 'rwhois://rwhois.xmission.com:4321') {
+            // Save a copy of the valid result before running the referral server
+            //  This is used in the event that the referral server fails
+            $prereferralResult = clone $Result;
             $referralServer = $Result->referral_server;
             $Result->reset();
             $mapping = $Config->get($referralServer);
             $template = str_replace('whois://', '', str_replace('rwhois://', '', $mapping['template']));
             $Config->setCurrent($Config->get($template));
+            $Config->prereferralResult = $prereferralResult;
             $WhoisParser->call();
         }
     }

--- a/Templates/Arin.php
+++ b/Templates/Arin.php
@@ -110,7 +110,7 @@ class Arin extends Regex
             }
         }
         
-        if (isset($Result->referral_server) && $Result->referral_server != '' && $Result->referral_server != 'rwhois://rwhois.shawcable.net:4321' && $Result->referral_server != 'rwhois://rwhois.perfectip.net:4321' && $Result->referral_server != 'rwhois://rwhois.xmission.com:4321') {
+        if (isset($Result->referral_server) && $Result->referral_server != '' && $Result->referral_server != 'rwhois://rwhois.psychz.net:4321' && $Result->referral_server != 'rwhois://rwhois.shawcable.net:4321' && $Result->referral_server != 'rwhois://rwhois.perfectip.net:4321' && $Result->referral_server != 'rwhois://rwhois.xmission.com:4321') {
             $referralServer = $Result->referral_server;
             $Result->reset();
             $mapping = $Config->get($referralServer);

--- a/Templates/Arin.php
+++ b/Templates/Arin.php
@@ -110,7 +110,7 @@ class Arin extends Regex
             }
         }
         
-        if (isset($Result->referral_server) && $Result->referral_server != '' && $Result->referral_server != 'rwhois://rwhois.shawcable.net:4321') {
+        if (isset($Result->referral_server) && $Result->referral_server != '' && $Result->referral_server != 'rwhois://rwhois.shawcable.net:4321' && $Result->referral_server != 'rwhois://rwhois.perfectip.net:4321') {
             $referralServer = $Result->referral_server;
             $Result->reset();
             $mapping = $Config->get($referralServer);


### PR DESCRIPTION
Perfect IP's RWhois server seems it doesn't want to connect when attempting to parse.

Implemented bypass for favoring ARIN data instead, proper Contacts provided in ARIN data.